### PR TITLE
Comment out module-dir parameter

### DIFF
--- a/powerdns/files/pdns.conf
+++ b/powerdns/files/pdns.conf
@@ -145,7 +145,7 @@ local-port={{ server.bind.port }}
 #################################
 # module-dir	Default directory for modules
 #
-module-dir=/usr/lib/powerdns
+# module-dir=/usr/lib/powerdns
 
 #################################
 # negquery-cache-ttl	Seconds to store packets in the PacketCache


### PR DESCRIPTION
For most modern popular distros (Ubuntu,CentOS,Debian) the module-dir points
to the wrong path. It should be /usr/lib/ARCH-linux-gnu/pdns
in case of Debian-based distros, or /usr/lib(64)/pdns for RH-based distros.
I presume, nothing bad will happend if this param will be commented out.